### PR TITLE
Setting memory storage limit for kinesis output

### DIFF
--- a/conf/kinesis_stream_and_managed_cloudwatch.conf
+++ b/conf/kinesis_stream_and_managed_cloudwatch.conf
@@ -12,6 +12,7 @@
     role_arn 	        ${KINESIS_ROLE_ARN}
     batch_size          ${KINESIS_BATCH_SIZE}
     Retry_Limit         False
+    storage.total_limit_size 512MB
 
 [OUTPUT]
     Name                cloudwatch_logs


### PR DESCRIPTION
See https://docs.fluentbit.io/manual/administration/buffering-and-storage

A later refinement may be to buffer to disk as well, the default is in memory. 